### PR TITLE
update link to github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ all recipes, not just those explicitly built for it.
 Repository
 ----------
 
-https://github.com/heavywater/chef-bag_config
+https://github.com/hw-cookbooks/bag_config
 
 Basic Usage
 ===========


### PR DESCRIPTION
The Repository section says:
https://github.com/heavywater/chef-bag_config

but the current home is
https://github.com/hw-cookbooks/bag_config
